### PR TITLE
Fix issue with character encoding

### DIFF
--- a/src/main/java/org/icatproject/icat/client/ICAT.java
+++ b/src/main/java/org/icatproject/icat/client/ICAT.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -84,7 +85,7 @@ public class ICAT {
 			if (entity == null) {
 				throw new IcatException(IcatExceptionType.INTERNAL, "No explanation provided");
 			} else {
-				error = EntityUtils.toString(entity);
+				error = EntityUtils.toString(entity, Charset.defaultCharset());
 			}
 			try (JsonParser parser = Json.createParser(new ByteArrayInputStream(error.getBytes()))) {
 				String code = null;
@@ -170,7 +171,7 @@ public class ICAT {
 		checkStatus(response);
 		HttpEntity entity = response.getEntity();
 		if (entity != null) {
-			String error = EntityUtils.toString(entity);
+			String error = EntityUtils.toString(entity, Charset.defaultCharset());
 			if (!error.isEmpty()) {
 				try (JsonParser parser = Json.createParser(new ByteArrayInputStream(error.getBytes()))) {
 					throw new IcatException(IcatExceptionType.INTERNAL, "No http entity expected in response " + error);
@@ -316,7 +317,7 @@ public class ICAT {
 		if (entity == null) {
 			throw new IcatException(IcatExceptionType.INTERNAL, "No http entity returned in response");
 		}
-		return EntityUtils.toString(entity);
+		return EntityUtils.toString(entity, Charset.defaultCharset());
 	}
 
 	private URI getUri(URIBuilder uriBuilder) throws IcatException {


### PR DESCRIPTION
This is a proposed fix for icatproject/icat.oaipmh#1

The `toString(HttpEntity entity)` method ([docs](https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/util/EntityUtils.html#toString(org.apache.http.HttpEntity))) falls back to the ISO-8859-1 character encoding by default which causes issues with non-ASCII characters.

Hence, this PR replaces the calls of this method with the extended `toString(HttpEntity entity, Charset defaultCharset)` method ([docs](https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/util/EntityUtils.html#toString(org.apache.http.HttpEntity,%20java.nio.charset.Charset))). The extended method takes an additional parameter which allows using the system's default encoding instead.