### PR TITLE
Change ICAT Ansible host references to use underscores

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: underscore_changes
+          ref: master
       
       - name: Setup Ansible
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,17 +47,18 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
+          ref: fix_warnings_#23
       
       - name: Setup Ansible
         run: |
           cd icat-ansible
-          echo -e "[icat-client-dev-hosts]\nlocalhost ansible_connection=local" > hosts
+          echo -e "[icat_client_dev_hosts]\nlocalhost ansible_connection=local" > hosts
           echo -e "icattravispw" > vault_pass.txt
           mv ../vault.yml ./group_vars/all
-          mv ../icat-client-dev-hosts.yml .
+          mv ../icat_client_dev_hosts.yml .
           sed -i -e "s/^payara_user: \"glassfish\"/payara_user: \"runner\"/" ./group_vars/all/vars.yml
           sed -i -e "s/python-pip/python3-pip/" ./roles/dev-common/tasks/main.yml
-          ansible-playbook --vault-password-file ./vault_pass.txt --inventory ./hosts ./icat-client-dev-hosts.yml
+          ansible-playbook --vault-password-file ./vault_pass.txt --inventory ./hosts ./icat_client_dev_hosts.yml
           cd ..
 
       - name: Test with Maven

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: fix_warnings_#23
+          ref: underscore_changes
       
       - name: Setup Ansible
         run: |
@@ -57,7 +57,7 @@ jobs:
           mv ../vault.yml ./group_vars/all
           mv ../icat_client_dev_hosts.yml .
           sed -i -e "s/^payara_user: \"glassfish\"/payara_user: \"runner\"/" ./group_vars/all/vars.yml
-          sed -i -e "s/python-pip/python3-pip/" ./roles/dev-common/tasks/main.yml
+          sed -i -e "s/python-pip/python3-pip/" ./roles/dev_common/tasks/main.yml
           ansible-playbook --vault-password-file ./vault_pass.txt --inventory ./hosts ./icat_client_dev_hosts.yml
           cd ..
 

--- a/icat_client_dev_hosts.yml
+++ b/icat_client_dev_hosts.yml
@@ -11,8 +11,8 @@
     - role: mariadb
     - role: icatdb
     - role: payara
-    - role: authn-simple
-    - role: authn-db
-    - role: icat-lucene
-    - role: dev-common
-    - role: icat-server
+    - role: authn_simple
+    - role: authn_db
+    - role: icat_lucene
+    - role: dev_common
+    - role: icat_server

--- a/icat_client_dev_hosts.yml
+++ b/icat_client_dev_hosts.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: icat-client-dev-hosts
+- hosts: icat_client_dev_hosts
   become: true
   vars_files:
     - 'group_vars/all/vars.yml'


### PR DESCRIPTION
## Description
A PR on ICAT Ansible (https://github.com/icatproject-contrib/icat-ansible/pull/32) causes breaking changes for this repo's CI. In a sentence, dashes of host names (and its respective host file names) are changed to underscores.

When https://github.com/icatproject-contrib/icat-ansible/pull/32 is merged, the ICAT Ansible branch on the CI needs to be changed back to master. I shall leave it as `fix_warnings_#23` for the time being because the CI won't pass otherwise.

## Testing Instructions
Just check that CI passes.

- [ ] Review code
- [ ] Check GitHub Actions build
