### PR TITLE
Upgrade to JakartaEE 10 API for compatibility with Payara 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>jakarta.platform</groupId>
 			<artifactId>jakarta.jakartaee-api</artifactId>
-			<version>9.1.0</version>
+			<version>10.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -95,9 +95,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>jakarta.json</artifactId>
-			<version>2.0.1</version>
+			<groupId>org.eclipse.parsson</groupId>
+			<artifactId>parsson</artifactId>
+			<version>1.1.0</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -150,7 +150,7 @@
 			<plugin>
 				<groupId>com.sun.xml.ws</groupId>
 				<artifactId>jaxws-maven-plugin</artifactId>
-				<version>3.0.2</version>
+				<version>4.0.0</version>
 				<executions>
 					<execution>
 						<id>execution1</id>

--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax</groupId>
-			<artifactId>javaee-api</artifactId>
-			<version>7.0</version>
+			<groupId>jakarta.platform</groupId>
+			<artifactId>jakarta.jakartaee-api</artifactId>
+			<version>9.1.0</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -96,7 +97,7 @@
 		<dependency>
 			<groupId>org.glassfish</groupId>
 			<artifactId>jakarta.json</artifactId>
-			<version>1.1.5</version>
+			<version>2.0.1</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -147,9 +148,9 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
+				<groupId>com.sun.xml.ws</groupId>
 				<artifactId>jaxws-maven-plugin</artifactId>
-				<version>2.6</version>
+				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>execution1</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.icatproject</groupId>
 	<artifactId>icat.client</artifactId>
-	<version>6.0.0-SNAPSHOT</version>
+	<version>6.0.0</version>
 	<packaging>jar</packaging>
 	<name>ICAT Clients</name>
 	<description>Provides facilities to login to an ICAT instance after which one can create, read, update or delete entities according to your permissions. This includes a Java client using SOAP access and a Java client using the REST interface of the icat.server.</description>
@@ -28,7 +28,7 @@
 		<connection>scm:git:https://github.com/icatproject/icat.client.git</connection>
 		<developerConnection>scm:git:https://github.com/icatproject/icat.client.git</developerConnection>
 		<url>https://github.com/icatproject/icat.client</url>
-		<tag>HEAD</tag>
+		<tag>v6.0.0</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.icatproject</groupId>
 	<artifactId>icat.client</artifactId>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>6.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>ICAT Clients</name>
 	<description>Provides facilities to login to an ICAT instance after which one can create, read, update or delete entities according to your permissions. This includes a Java client using SOAP access and a Java client using the REST interface of the icat.server.</description>
@@ -117,11 +117,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.10.1</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
-					<source>1.8</source>
-					<target>1.8</target>
+					<release>11</release>
 				</configuration>
 			</plugin>
 
@@ -148,9 +147,9 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.jvnet.jax-ws-commons</groupId>
+				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>jaxws-maven-plugin</artifactId>
-				<version>2.3</version>
+				<version>2.6</version>
 				<executions>
 					<execution>
 						<id>execution1</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.icatproject</groupId>
 	<artifactId>icat.client</artifactId>
-	<version>6.0.0</version>
+	<version>6.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>ICAT Clients</name>
 	<description>Provides facilities to login to an ICAT instance after which one can create, read, update or delete entities according to your permissions. This includes a Java client using SOAP access and a Java client using the REST interface of the icat.server.</description>
@@ -28,7 +28,7 @@
 		<connection>scm:git:https://github.com/icatproject/icat.client.git</connection>
 		<developerConnection>scm:git:https://github.com/icatproject/icat.client.git</developerConnection>
 		<url>https://github.com/icatproject/icat.client</url>
-		<tag>v6.0.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<issueManagement>

--- a/src/main/java/org/icatproject/icat/client/ICAT.java
+++ b/src/main/java/org/icatproject/icat/client/ICAT.java
@@ -17,15 +17,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.json.Json;
-import javax.json.JsonException;
-import javax.json.JsonReader;
-import javax.json.JsonString;
-import javax.json.JsonValue;
-import javax.json.stream.JsonGenerator;
-import javax.json.stream.JsonParser;
-import javax.json.stream.JsonParser.Event;
-import javax.json.stream.JsonParsingException;
+import jakarta.json.Json;
+import jakarta.json.JsonException;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParser.Event;
+import jakarta.json.stream.JsonParsingException;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -79,9 +79,15 @@
 		&#160;&#160;&#160;&#160;&#160;&#160;&lt;version&gt;${project.version}&lt;/version&gt;
 		<br /> &#160;&#160;&#160;&lt;/dependency&gt; <br /> <br />
 		&nbsp;&nbsp;&nbsp;&lt;dependency&gt; <br />
-		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;groupId&gt;org.glassfish&lt;/groupId&gt;<br />
-		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;artifactId&gt;jakarta.json&lt;/artifactId&gt;<br />
-		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;version&gt;1.1.5&lt;/version&gt;<br />
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;groupId&gt;org.eclipse.parsson&lt;/groupId&gt;<br />
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;artifactId&gt;parsson&lt;/artifactId&gt;<br />
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;version&gt;1.1.0&lt;/version&gt;<br />
+		&nbsp;&nbsp;&nbsp;&lt;/dependency&gt;<br /> &#160;&#160;&#160;... <br />
+		&lt;/dependencies&gt; <br /> <br />
+		&nbsp;&nbsp;&nbsp;&lt;dependency&gt; <br />
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;groupId&gt;com.sun.xml.ws&lt;/groupId&gt;<br />
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;artifactId&gt;jaxws-rt&lt;/artifactId&gt;<br />
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;version&gt;4.0.0&lt;/version&gt;<br />
 		&nbsp;&nbsp;&nbsp;&lt;/dependency&gt;<br /> &#160;&#160;&#160;... <br />
 		&lt;/dependencies&gt;
 	</code>

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -6,6 +6,9 @@
 
 	<h1>ICAT Client Release Notes</h1>
 
+	<h2>6.0.0</h2>
+	<p>Upgrade from JavaEE to JakartaEE 10. Requires Java 11+.</p>
+
 	<h2>5.0.0</h2>
 	<p>Support for ICAT server 5</p>
 	<p>A python client is no longer included. python-icat should be used.</p>

--- a/src/test/java/org/icatproject/icat/TestIcatClient.java
+++ b/src/test/java/org/icatproject/icat/TestIcatClient.java
@@ -11,10 +11,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.json.Json;
-import javax.json.JsonNumber;
-import javax.json.JsonValue;
-import javax.json.stream.JsonGenerator;
+import jakarta.json.Json;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
 
 import org.icatproject.icat.client.ICAT;
 import org.icatproject.icat.client.IcatException;

--- a/src/test/java/org/icatproject/icat/TestIcatClient.java
+++ b/src/test/java/org/icatproject/icat/TestIcatClient.java
@@ -106,7 +106,7 @@ public class TestIcatClient {
 
 	@Test
 	public void testInfo() throws Exception {
-		assertTrue(icat.getVersion().startsWith("5.0."));
+		assertTrue(icat.getVersion().startsWith("6.0."));
 	}
 
 }


### PR DESCRIPTION
Changes the imports of JavaEE classes in the `javax` namespace to the `jakarta` namespace, and increases the Java requirement to version 11 since that is the minimum supported by Jakarta EE 10. These are both breaking changes so this is a new major version.

This has already been released as version 6.0.0.